### PR TITLE
Remove iptools and use just netaddr

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get -q update && apt-get install -yf nodejs
 
 # Configuration script dependencies
 RUN apt-get update && apt-get install -y python-pip
-RUN pip install pystache iptools
+RUN pip install pystache
 
 # create djbdns accounts Gtinydns, Gdnslog
 RUN adduser --force-badname --no-create-home --disabled-login --shell /bin/false Gdnslog

--- a/docker/templates/config.py
+++ b/docker/templates/config.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 import pystache
-from iptools import IpRangeList
+from netaddr import IPSet
 
 
 def pem_is_valid(pem):
@@ -45,8 +45,9 @@ def main():
     trusted_list = trusted_ips.split(',')
 
     try:
-        trusted_ip_range = IpRangeList(*trusted_list)
-    except Exception:
+        trusted_ip_range = IPSet(trusted_list)
+    except Exception as e:
+        print >> sys.stderr, trusted_list, e
         print >> sys.stderr, "Problem parsing TRUSTED_IPS environment variable"
         sys.exit(1)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,3 @@ tox==1.9.2
 virtualenv==12.1.1
 Werkzeug==0.10.4
 wheel==0.24.0
-iptools==0.6.1

--- a/vegadns/api/common.py
+++ b/vegadns/api/common.py
@@ -2,7 +2,7 @@ import re
 import time
 
 from flask import request
-from iptools import IpRangeList
+from netaddr import IPSet
 import peewee
 
 from vegadns.api.config import config
@@ -113,7 +113,7 @@ class Auth(object):
         trusted = "".join(trusted.split())  # remove whitespace
         trusted_list = trusted.split(',')
         try:
-            ip_range = IpRangeList(*trusted_list)
+            ip_range = IPSet(trusted_list)
         except:
             raise AuthException('Error parsing IP acl list')
 


### PR DESCRIPTION
iptools IPRangeList is roughly equivalent to netaddr.IPSet (at least for their
usage in VegaDNS.)  This means we don't need 2 libraries for IP address handling