### PR TITLE
Declare dbConnected as global in api/__init__.py

### DIFF
--- a/vegadns/api/__init__.py
+++ b/vegadns/api/__init__.py
@@ -98,6 +98,8 @@ def set_request_id():
 @app.before_request
 def db_connect():
     """ create DB connection """
+    global dbConnected
+
     attempts = 5
     while attempts > 0:
         try:


### PR DESCRIPTION
Because of where it is used in db_connect() the global dbConnected is never set so we never disconnect during teardown. Declaring it as being the global dbConnected means we now properly disconnect the database connection and MySQL stops yelling at me about "(Got an error reading communication packets)"