### PR TITLE
chown'ing everything is a little much

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN pip install --upgrade /var/www/vegadns2/vegadns-cli
 RUN chmod +x /var/www/vegadns2/vegadns-ui/build.sh
 RUN /var/www/vegadns2/vegadns-ui/build.sh
 
-RUN chown -R www-data:www-data /var/www/vegadns2
+RUN chown -R www-data:www-data /var/www/vegadns2/vegadns-ui/public
 
 # remove default nginx config
 RUN rm -f /etc/nginx/sites-enabled/default


### PR DESCRIPTION
the current chown causes over 100K files to be chown'd (since it includes node_modules).  This takes forever on my mac.  In reality the only thing nginx cares about is the public directory, so by only chown'ing that we save a ton of time and useless chown'ing.