### PR TITLE
Add TTL to CAA records

### DIFF
--- a/vegadns/api/export/tinydns.py
+++ b/vegadns/api/export/tinydns.py
@@ -111,6 +111,7 @@ class ExportTinydnsData(object):
                 "\%03o" % len(caa_split[1]) + \
                 "".join("\%03o" % ord(c) for c in caa_split[1]) + \
                 "".join("\%03o" % ord(c) for c in caa_split[2]) + \
+                ":" + str(model.ttl)
                 "\n"
 
     def export_domain(self, domain_name, records):


### PR DESCRIPTION
This was inadvertently left off the initial implementation, currently CAA records inherit the SOA's expirey.